### PR TITLE
Fix timeout failure when a page only contain pictures.

### DIFF
--- a/weread_exporter/webpage.py
+++ b/weread_exporter/webpage.py
@@ -396,13 +396,13 @@ class WeReadWebPage(object):
             if result:
                 break
             await asyncio.sleep(1)
-        else:
-            raise RuntimeError("Wait for creating markdown timeout")
         script = "canvasContextHandler.data.markdown;"
         result = await self._page.evaluate(script)
         if not result:
             await self._page.evaluate("canvasContextHandler.updateMarkdown();")
             result = await self._page.evaluate(script)
+            if not result:
+                raise RuntimeError("Wait for creating markdown timeout")
         return result
 
     async def _check_next_page(self):


### PR DESCRIPTION
当有些书页并不包括任何文字，而仅仅有图片时，会出现“Wait for creating markdown error". 下面这本书的最后一页可以重现这个问题。 https://weread.qq.com/web/bookDetail/04c32560813ab8b83g018249

![image](https://github.com/drunkdream/weread-exporter/assets/12515653/6064ba2a-686d-4f4b-bf15-5f1cf9629ee2)

这个PR修复了这个问题，如果页面上没有文字，`canvasContextHandler.data.complete` 不会被设为true，`get_markdown` 不应该急于抛出异常，应该继续使用`canvasContextHandler.updateMarkdown()`来读取图片。